### PR TITLE
feat: Use exception groups instead of string concatenating when returning multiple errors

### DIFF
--- a/src/requela/rules.py
+++ b/src/requela/rules.py
@@ -149,7 +149,10 @@ class ModelRQLRules:
                 )
 
         if errors:
-            raise ValueError("\n".join(errors))
+            raise ExceptionGroup(
+                f"Model validation failed for '{self.__model__.__name__}'",
+                [ValueError(error_msg) for error_msg in errors],
+            )
 
     def _get_field_type(self, field_name: str) -> type:
         """Gets the type of a field - to be implemented by specific ORM builders"""

--- a/tests/sqlalchemy/test_rules.py
+++ b/tests/sqlalchemy/test_rules.py
@@ -85,10 +85,12 @@ def test_filter_class_invalid_operator_for_field():
         __model__ = User
         role = FieldRule(allowed_operators=[Operator.LTE, Operator.GTE])
 
-    with pytest.raises(
-        ValueError, match="Invalid operators 'gte', 'lte' for field 'role' of type 'UserRole'."
-    ):
+    with pytest.raises(ExceptionGroup, match="Model validation failed for 'User'") as exc:
         UserRules()
+
+    assert [(e.__class__, str(e)) for e in exc.value.exceptions] == [
+        (ValueError, "Invalid operators 'gte', 'lte' for field 'role' of type 'UserRole'."),
+    ]
 
 
 def test_filter_class_unexisting_field():
@@ -96,8 +98,27 @@ def test_filter_class_unexisting_field():
         __model__ = User
         banana = FieldRule()
 
-    with pytest.raises(ValueError, match="Field 'banana' not found in model 'User'."):
+    with pytest.raises(ExceptionGroup, match="Model validation failed for 'User'") as exc:
         UserRules()
+
+    assert [(e.__class__, str(e)) for e in exc.value.exceptions] == [
+        (ValueError, "Field 'banana' not found in model 'User'."),
+    ]
+
+
+def test_multiple_exceptions_raised():
+    class UserRules(ModelRQLRules):
+        __model__ = User
+        role = FieldRule(allowed_operators=[Operator.LTE, Operator.GTE])
+        banana = FieldRule()
+
+    with pytest.raises(ExceptionGroup, match="Model validation failed for 'User'") as exc:
+        UserRules()
+
+    assert [(e.__class__, str(e)) for e in exc.value.exceptions] == [
+        (ValueError, "Field 'banana' not found in model 'User'."),
+        (ValueError, "Invalid operators 'gte', 'lte' for field 'role' of type 'UserRole'."),
+    ]
 
 
 def test_filter_class_order_field_not_allowed():


### PR DESCRIPTION
Exception groups are a new addition to Python 3.11 and they allow us to group multiple exceptions and raise them together -- requela is a great use case for them. There is also a new `except*` syntax for catching individual exceptions which would be quite useful once we break down and categorise the different exception types the library can raise.